### PR TITLE
Resolve page flicker on initial request

### DIFF
--- a/app/router.tsx
+++ b/app/router.tsx
@@ -147,8 +147,8 @@ const RouterProvider: React.FC<React.PropsWithChildren> = (props) => {
         {state === 'initial' && (
           <motion.div
             variants={{
-              initial: { opacity: 1, position: 'fixed', inset: 0 },
-              intro: { opacity: 0, position: 'fixed', inset: 0 },
+              initial: { opacity: 1 },
+              intro: { opacity: 0 },
             }}
             initial="initial"
             exit="intro"
@@ -156,6 +156,7 @@ const RouterProvider: React.FC<React.PropsWithChildren> = (props) => {
               if (definition === 'intro') setState('idle');
             }}
             className="bg-gradient-to-tl from-slate-1 to-slate-2 z-40 pointer-events-none will-change-motion"
+            style={{ position: 'fixed', inset: 0, backgroundColor: 'red' }}
             transition={{ duration: 0.6 }}
           />
         )}

--- a/app/router.tsx
+++ b/app/router.tsx
@@ -147,15 +147,15 @@ const RouterProvider: React.FC<React.PropsWithChildren> = (props) => {
         {state === 'initial' && (
           <motion.div
             variants={{
-              initial: { opacity: 1 },
-              intro: { opacity: 0 },
+              initial: { opacity: 1, position: 'fixed', inset: 0 },
+              intro: { opacity: 0, position: 'fixed', inset: 0 },
             }}
             initial="initial"
             exit="intro"
             onAnimationComplete={(definition) => {
               if (definition === 'intro') setState('idle');
             }}
-            className="fixed inset-0 bg-gradient-to-tl from-slate-1 to-slate-2 z-40 pointer-events-none will-change-motion"
+            className="bg-gradient-to-tl from-slate-1 to-slate-2 z-40 pointer-events-none will-change-motion"
             transition={{ duration: 0.6 }}
           />
         )}


### PR DESCRIPTION
Not sure what's happening here, CSS in presumably a blocking resource so not sure why the styles take a frame to apply the fixed position.

Testing this by inlining the style server side.


https://github.com/user-attachments/assets/5ffb0a87-a3c5-4641-b052-331a3cfb48db

