### PR TITLE
Fix icon reflow in link tooltips

### DIFF
--- a/app/(projects)/_components/tooltip-link.tsx
+++ b/app/(projects)/_components/tooltip-link.tsx
@@ -21,11 +21,11 @@ export const TooltipLink = React.forwardRef<TooltipLinkElement, TooltipLinkProps
       <Tooltip
         content={
           <div className="font-body font-medium text-sm text-slate-light-11 flex items-center gap-2">
-            <div className="relative bg-slate-light-5 rounded-full overflow-hidden">
+            <div className="relative bg-slate-light-5 rounded-full overflow-hidden size-3">
               <ExternalFavicon
                 image={{ src: props.href, alt: 'favicon', color: null }}
-                className="size-3"
                 fill
+                className="size-full"
               />
             </div>
             <div className="capsize">

--- a/components/tooltip.tsx
+++ b/components/tooltip.tsx
@@ -54,9 +54,14 @@ export const Tooltip = React.forwardRef<TooltipElement, TooltipProps>((props, fo
                     key={`${side}-${align}`}
                     {...tooltipProps}
                     className={cx('bg-slate-light-1 p-4 rounded-lg shadow-lg', className)}
-                    initial={{ opacity: 0, scale: 0.75, [axis]: 10 * (inverseSide ? -1 : 1) }}
+                    initial={{ opacity: 0, scale: 0.85, [axis]: 10 * (inverseSide ? -1 : 1) }}
                     animate={{ opacity: 1, scale: 1, [axis]: 0 }}
                     exit={{ opacity: 0, scale: 0.95, [axis]: 2 * (inverseSide ? -1 : 1) }}
+                    transition={{
+                      type: 'spring',
+                      duration: 0.3,
+                      bounce: 0.25,
+                    }}
                     style={{
                       originX: 'var(--floating-transform-origin-x)',
                       originY: 'var(--floating-transform-origin-y)',


### PR DESCRIPTION
When I changed the fill strategy for image loading I forgot to move the dimension application to some containers.

Before:

https://github.com/user-attachments/assets/b6d0e516-3f63-4423-a2bd-f4cef71d2704

After:

https://github.com/user-attachments/assets/515e1931-c405-439d-bfa3-ca418c5cbd4e

