### PR TITLE
Fix CV prefetch error

### DIFF
--- a/app/router.tsx
+++ b/app/router.tsx
@@ -272,17 +272,20 @@ type NextLinkProps = React.ComponentPropsWithoutRef<typeof NextLink>;
 interface RouterLinkProps extends NextLinkProps {
   href: string;
   newTab?: boolean;
+  external?: boolean;
 }
 
 const RouterLink = React.forwardRef<RouterLinkElement, RouterLinkProps>((props, forwardedRef) => {
-  const { newTab, ...linkProps } = props;
+  const { newTab, external, ...linkProps } = props;
   const context = useRouterContext();
 
-  const isExternal = props.href.startsWith('https://');
+  const isExternal = external ?? props.href.startsWith('https://');
   const externalProps =
     isExternal || newTab
       ? { target: '_blank', rel: isExternal ? 'noopener noreferrer' : undefined }
       : {};
+
+  if (isExternal) return <a {...linkProps} {...externalProps} ref={forwardedRef} />;
 
   return (
     <NextLink
@@ -290,8 +293,6 @@ const RouterLink = React.forwardRef<RouterLinkElement, RouterLinkProps>((props, 
       ref={forwardedRef}
       onClick={(event) => {
         props.onClick?.(event);
-
-        if (isExternal) return;
 
         if (!event.isDefaultPrevented() && !isModifiedEvent(event)) {
           event.preventDefault();
@@ -349,8 +350,10 @@ RouterTransition.displayName = 'RouterTransition';
 
 type RouterImageElement = React.ComponentRef<typeof NextImage>;
 
-interface RouterImageProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof NextImage>, 'src' | 'alt'> {
+interface RouterImageProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof NextImage>,
+  'src' | 'alt'
+> {
   image: ImageWithMetadata;
 }
 

--- a/app/sidebar.tsx
+++ b/app/sidebar.tsx
@@ -333,7 +333,7 @@ const SidebarMenuContent = React.forwardRef<SidebarMenuContentElement, SidebarMe
                   <SidebarSubListItem href="/">Home</SidebarSubListItem>
                   <SidebarSubListItem href="/#experience">Experience</SidebarSubListItem>
                   <SidebarSubListItem href="/#testimonials">Recommendations</SidebarSubListItem>
-                  <SidebarSubListItem href="/cv" newTab>
+                  <SidebarSubListItem href="/cv" newTab external>
                     Download CV
                   </SidebarSubListItem>
                 </motion.ul>
@@ -460,8 +460,10 @@ const sidebarProjectLinkLine = cva({
 
 type SidebarProjectLinkElement = React.ComponentRef<typeof RouterLink>;
 
-interface SidebarProjectLinkProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof RouterLink>, 'href'> {
+interface SidebarProjectLinkProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof RouterLink>,
+  'href'
+> {
   projectId: ProjectId;
   title: string;
   path: string;


### PR DESCRIPTION
`/cv` is just a redirect to the static PDF. Next was attempted to prefetch RSC payload, hence the error only when opening the sidebar.