### PR TITLE
Add sticky artifact info

### DIFF
--- a/app/(projects)/artifacts/_components/artifact-grid.tsx
+++ b/app/(projects)/artifacts/_components/artifact-grid.tsx
@@ -79,28 +79,29 @@ export const ArtifactGridItem = React.forwardRef<ArtifactGridItemElement, Artifa
             <div className={cx('absolute', 'inset-[6vw]', 'sm:inset-[3vw]', 'wide:inset-[1.5vw]')}>
               <AnimatePresence>
                 {hovered && (
-                  <Chip.Root className="top-6 right-6" asChild>
-                    <motion.div
-                      initial="hidden"
-                      animate="visible"
-                      exit="hidden"
-                      variants={{
-                        hidden: { y: -2, opacity: 0 },
-                        visible: { y: 0, opacity: 1 },
-                      }}
-                      transition={{
-                        type: 'spring',
-                        stiffness: 500,
-                        damping: 25,
-                        mass: 0.25,
-                      }}
-                    >
+                  <motion.div
+                    initial="hidden"
+                    animate="visible"
+                    exit="hidden"
+                    variants={{
+                      hidden: { y: -2, opacity: 0 },
+                      visible: { y: 0, opacity: 1 },
+                    }}
+                    transition={{
+                      type: 'spring',
+                      stiffness: 500,
+                      damping: 25,
+                      mass: 0.25,
+                    }}
+                    className="z-10 sticky top-0 inset-x-0 p-6 flex justify-end"
+                  >
+                    <Chip.Root>
                       <Chip.Text>{label}</Chip.Text>
                       <Chip.Icon side="right">
                         <InformationCircleIcon />
                       </Chip.Icon>
-                    </motion.div>
-                  </Chip.Root>
+                    </Chip.Root>
+                  </motion.div>
                 )}
               </AnimatePresence>
 

--- a/app/(projects)/artifacts/page.tsx
+++ b/app/(projects)/artifacts/page.tsx
@@ -22,9 +22,7 @@ export default function ArtifactsPage() {
       >
         <RouterTransition
           multiplier={15}
-          className={cx(
-            'z-10 relative bg-slate-12 p-4 md:p-12 lg:p-16 2xl:p-[6vw] overflow-hidden',
-          )}
+          className={cx('z-10 relative bg-slate-12 p-4 md:p-12 lg:p-16 2xl:p-[6vw]')}
         >
           <ArtifactGrid.Root>
             {artifacts.map(({ name, year, src }, index) => (

--- a/app/router.tsx
+++ b/app/router.tsx
@@ -114,7 +114,9 @@ const RouterProvider: React.FC<React.PropsWithChildren> = (props) => {
         }
       }}
     >
-      <div className={cx(state !== 'idle' && 'pointer-events-none')}>{children}</div>
+      <div className={cx(state !== 'idle' && 'pointer-events-none overflow-hidden')}>
+        {children}
+      </div>
       <AnimatePresence>
         {(state === 'initial' || state === 'cover') && (
           <motion.div

--- a/app/router.tsx
+++ b/app/router.tsx
@@ -114,9 +114,7 @@ const RouterProvider: React.FC<React.PropsWithChildren> = (props) => {
         }
       }}
     >
-      <div className={cx(state !== 'idle' && 'pointer-events-none', 'overflow-hidden')}>
-        {children}
-      </div>
+      <div className={cx(state !== 'idle' && 'pointer-events-none')}>{children}</div>
       <AnimatePresence>
         {(state === 'initial' || state === 'cover') && (
           <motion.div

--- a/components/chip.tsx
+++ b/components/chip.tsx
@@ -19,7 +19,7 @@ export const Chip = React.forwardRef<ChipElement, ChipProps>(
       <Comp
         {...props}
         className={cx(
-          'bg-slate-2 absolute text-slate-12 z-10 font-body font-semibold text-xs lg:text-sm py-2 px-3.5 rounded-full flex items-center gap-1 lg:gap-1.5',
+          'bg-slate-2 text-slate-12 z-10 font-body font-semibold text-xs lg:text-sm py-2 px-3.5 rounded-full flex items-center gap-1 lg:gap-1.5',
           className,
         )}
         ref={forwardedRef}

--- a/components/work-item.tsx
+++ b/components/work-item.tsx
@@ -112,7 +112,10 @@ export const WorkItem = React.forwardRef<WorkItemElement, WorkItemProps>(
                 >
                   {project.type === 'personal' && (
                     <Chip.Root
-                      className={isLarge ? 'top-5 right-5 lg:top-8 lg:right-8' : 'top-5 right-5'}
+                      className={cx(
+                        'absolute',
+                        isLarge ? 'top-5 right-5 lg:top-8 lg:right-8' : 'top-5 right-5',
+                      )}
                     >
                       <Chip.Icon side="left">
                         <BookOpenIcon />


### PR DESCRIPTION
The thumbnails are intentionally pretty large, however this causes info rollovers to quickly become obscured. This change sticks info tips such that they remain rendered in view.